### PR TITLE
rfnoc: adding pyqt5 dependency

### DIFF
--- a/rfnoc.lwr
+++ b/rfnoc.lwr
@@ -1,8 +1,8 @@
 # Initializes a prefix with the necessary configuration to support RFNoC and RFNoC modtool
-inherit: prefix 
+inherit: prefix
 config:
     packages:
-        uhd: 
+        uhd:
             gitbranch: rfnoc-devel
             forcebuild: True
         gnuradio:
@@ -16,4 +16,5 @@ depends:
 - gnuradio
 - uhd
 - gr-ettus
+- pyqt5
 - uhd-fpga


### PR DESCRIPTION
Adding this here for the uhd_image_builder_gui.py. The pyqt5 recipe was proposed in a PR in the gr-recipes repository from GNURadio.