### PR TITLE
Set GNU Radio branch to maint-3.7. 

### DIFF
--- a/e3xx-custom-uhd.lwr
+++ b/e3xx-custom-uhd.lwr
@@ -30,6 +30,7 @@ config:
         gnuradio:
             forceinstalled: False
             forcebuild: True
+            gitbranch: maint-3.7
             config_filter: |
                    cmake .. \
                    -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/oe-sdk_cross.cmake \

--- a/e3xx-latest-maint.lwr
+++ b/e3xx-latest-maint.lwr
@@ -31,6 +31,7 @@ config:
         gnuradio:
             forceinstalled: False
             forcebuild: True
+            gitbranch: maint-3.7
             config_filter: |
                    cmake .. \
                    -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/oe-sdk_cross.cmake \

--- a/e3xx-rfnoc.lwr
+++ b/e3xx-rfnoc.lwr
@@ -33,6 +33,7 @@ config:
         gnuradio:
             forceinstalled: False
             forcebuild: True
+            gitbranch: maint-3.7
             config_filter: |
                    cmake .. \
                    -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/oe-sdk_cross.cmake \

--- a/rfnoc.lwr
+++ b/rfnoc.lwr
@@ -8,6 +8,7 @@ config:
             vars:
               config_opt: " -DENABLE_RFNOC=ON "
         gnuradio:
+            gitbranch: maint-3.7
             forcebuild: True
         gr-ettus:
             gitbranch: master


### PR DESCRIPTION
As mentioned in https://github.com/EttusResearch/gr-ettus/issues/41, the lack of git branch for these recipes was pulling a newer GNURadio version that is probably incompatible with the current gr-ettus. I've set the revision to maint-3.7, as also suggested in the issue. 